### PR TITLE
Bug 30952: (follow-up) Fix style of floating toolbars

### DIFF
--- a/koha-tmpl/intranet-tmpl/prog/css/preferences.css
+++ b/koha-tmpl/intranet-tmpl/prog/css/preferences.css
@@ -97,8 +97,10 @@ h3.collapsed i.fa.fa-caret-down::before {
 }
 
 #toolbar.floating {
-    box-shadow: 0 3px 2px 0 rgba(0, 0, 0, 0.5);
     border-radius: 0;
+    box-shadow: 0 0 2px 1px rgba(0,0,0,.4);
+    margin-top: 0;
+    z-index: 100;
 }
 
 .loading {

--- a/koha-tmpl/intranet-tmpl/prog/css/src/_tables.scss
+++ b/koha-tmpl/intranet-tmpl/prog/css/src/_tables.scss
@@ -79,6 +79,10 @@ table {
         margin-top: .5em;
         margin-bottom: .5em;
 
+        &.fixedHeader-floating {
+            margin-top: 0;
+        }
+
         &.no-footer {
             border: none;
         }

--- a/koha-tmpl/intranet-tmpl/prog/css/src/_toolbar.scss
+++ b/koha-tmpl/intranet-tmpl/prog/css/src/_toolbar.scss
@@ -17,8 +17,8 @@
 
     &.floating {
         border-radius: 0;
+        box-shadow: 0 0 2px 1px rgba(0,0,0,.4);
         margin-top: 0;
-        box-shadow: 0 3px 2px 0 rgba(0, 0, 0, .5);
         z-index: 100;
     }
 

--- a/koha-tmpl/intranet-tmpl/prog/css/src/staff-global.scss
+++ b/koha-tmpl/intranet-tmpl/prog/css/src/staff-global.scss
@@ -2063,8 +2063,7 @@ li {
 
 .searchheader {
     background-color: #f3f4f4;
-    border: 1px solid #696969;
-    border-radius: 5px 5px 5px 5px;
+    box-shadow: 0 0 2px 1px rgba(0,0,0,.2);
     font-size: 80%;
     margin-top: .5em;
     margin-bottom: .5em;
@@ -2075,7 +2074,10 @@ li {
 
     &.floating {
         border-radius: 0;
+        box-shadow: 0 0 2px 1px rgba(0,0,0,.4);
         margin-top: 0;
+        margin-bottom: 0;
+        z-index: 100;
     }
 
     .btn-group {


### PR DESCRIPTION
This patch makes some changes to floating toolbars, both hc-sticky toolbars and DataTables floating toolbars. The changes fix some bugs in the display (incorrect z-index, unwanted margins) and proposes a different style for .searchheader-style toolbars (e.g. patron search results).

To test, apply the patch and rebuild the staff interface CSS. Test pages with various kinds and combinations of floating toolbars, e.g.:

- Administration -> System preferences
- Patrons -> Patron search results
- Administration -> Libraries
- Catalog search results