### PR TITLE
Bug 30952: (follow-up) Use variables for primary and secondary greens

### DIFF
--- a/koha-tmpl/intranet-tmpl/prog/css/src/_header.scss
+++ b/koha-tmpl/intranet-tmpl/prog/css/src/_header.scss
@@ -44,9 +44,9 @@ a.navbar-toggle {
 }
 
 #header_search {
-    background-color: #418940;
+    background-color: $background-color-primary;
     border-radius: 0;
-    border: 1px solid #418940;
+    border: 1px solid $background-color-primary;
     display: flex;
     padding: 0 .8em;
 
@@ -69,7 +69,7 @@ a.navbar-toggle {
         display: flex;
         align-items: center;
         color: white;
-        background-color: #418940;
+        background-color: $background-color-primary;
         z-index: 2;
         flex-grow: 1;
 
@@ -105,7 +105,7 @@ a.navbar-toggle {
 
     .form-title {
         padding: 0 16px 0 0;
-        background-color: #418940;
+        background-color: $background-color-primary;
         border-radius: 0 16px 16px 0;
         display: flex;
         align-items: center;
@@ -153,7 +153,7 @@ a.navbar-toggle {
         background-color: white;
         padding: 1em;
         border-radius: 0 0 8px 8px;
-        border: 1px solid #418940;
+        border: 1px solid $background-color-primary;
         border-top: 0 none;
         box-shadow: 0 2px 2px 1px #00000030;
         z-index: 1;
@@ -180,7 +180,7 @@ a.navbar-toggle {
 
     input[type="submit"], button[type="submit"] {
         height: 31px;
-        background-color: #71B443;
+        background-color: $background-color-secondary;
         color: white;
         border: 0;
         text-shadow: unset;
@@ -208,7 +208,7 @@ a.navbar-toggle {
 
 #lastborrower-window {
     display: none;
-    background-image: linear-gradient(to left, #418940, #71B443);
+    background-image: linear-gradient(to left, $background-color-primary, $background-color-secondary);
     box-shadow: 1px 1px 1px 0 #999;
     color: #FFFFFF;
     padding: .2em;

--- a/koha-tmpl/intranet-tmpl/prog/css/src/_variables.scss
+++ b/koha-tmpl/intranet-tmpl/prog/css/src/_variables.scss
@@ -1,5 +1,6 @@
 $green-text-color: #006100;
 $background-color-primary: #418940;
+$background-color-secondary: lighten(saturate(adjust-hue($background-color-primary, -24), 9), 9);
 
 // Copied from Bootstrap 5 without system-ui because of
 // https://infinnie.github.io/blog/2017/systemui.html

--- a/koha-tmpl/intranet-tmpl/prog/css/src/staff-global.scss
+++ b/koha-tmpl/intranet-tmpl/prog/css/src/staff-global.scss
@@ -5,7 +5,7 @@
 @import "fonts";
 
 ::selection {
-    background: #418940;
+    background: $background-color-primary;
     color: #FFFFFF;
 }
 
@@ -64,7 +64,7 @@ a {
     }
 
     &.clear_date {
-        color: #418940;
+        color: $background-color-primary;
         font-size: 130%;
         vertical-align: middle;
 
@@ -78,7 +78,7 @@ a {
         i, img {
             text-align: center;
             color: $green-text-color;
-            border: solid 3px #71B443;
+            border: solid 3px $background-color-secondary;
             border-radius: 50%;
             background-color: transparent;
             width: 40px;
@@ -95,14 +95,14 @@ a {
         }
 
         &:hover {
-            color: #418940;
+            color: $background-color-primary;
             text-decoration: none;
             font-weight: bold;
 
             i, img {
-                border-color: #418940;
+                border-color: $background-color-primary;
                 background-color: transparent;
-                color: #418940;
+                color: $background-color-primary;
             }
 
         }
@@ -403,8 +403,8 @@ aside {
             &.active > a, a:hover, a.current {
                 background-color: #F3F4F4;
                 text-decoration: none;
-                color: #418940;
-                border-left: solid 5px #418940;
+                color: $background-color-primary;
+                border-left: solid 5px $background-color-primary;
                 font-weight: bold;
             }
         }
@@ -623,7 +623,7 @@ cite {
 input,
 textarea {
     &:focus {
-        border-color: #418940;
+        border-color: $background-color-primary;
         border-radius: 4px;
     }
 }
@@ -1523,7 +1523,7 @@ i {
     }
 
     &.success {
-        color: #418940;
+        color: $background-color-primary;
     }
 
     &.warn {
@@ -1791,7 +1791,7 @@ i {
     background-color: #FEC32C;
     i {
         &.fa {
-            color: #418940;
+            color: $background-color-primary;
         }
     }
 }
@@ -2670,7 +2670,7 @@ td.bundle {
 .ui-widget-content {
     background: #FFFFFF none;
     border-radius: 4px;
-    border: 3px solid #418940;
+    border: 3px solid $background-color-primary;
     color: #222222;
 }
 
@@ -2784,7 +2784,7 @@ td.bundle {
     .ui-tabs-panel {
         background: #FFF none;
         border-radius: 4px;
-        border: 3px solid #418940;
+        border: 3px solid $background-color-primary;
 
         fieldset {
             box-shadow: none;
@@ -2792,13 +2792,13 @@ td.bundle {
     }
     .ui-tabs-nav {
         li {
-            background: #71B443;
+            background: $background-color-secondary;
             border: 0;
             margin-right: .4em;
             border-radius: 4px 4px 0 0;
 
             &.ui-tabs-active, &.ui-state-hover {
-                background-color: #418940;
+                background-color: $background-color-primary;
                 border-radius: 4px 4px 0 0;
                 border: 0;
                 border-bottom-width: 0;
@@ -2831,11 +2831,11 @@ td.bundle {
 
     .ui-state-hover {
         a {
-            color: #418940;
+            color: $background-color-primary;
 
             &:link,
             &:visited {
-                color: #418940;
+                color: $background-color-primary;
             }
         }
     }
@@ -2940,13 +2940,13 @@ td.bundle {
             position: relative;
             top: 1px;
             white-space: nowrap;
-            background: #71B443;
+            background: $background-color-secondary;
 
             &.active, &:hover {
                 font-weight: normal;
                 padding-bottom: 1px;
 
-                background-color: #418940;
+                background-color: $background-color-primary;
                 border: 0;
                 border-bottom-width: 0;
 
@@ -2975,7 +2975,7 @@ td.bundle {
 
     .tabs-container {
         background: none repeat scroll 0 0 transparent;
-        border: 3px solid #418940;
+        border: 3px solid $background-color-primary;
         border-radius: 4px;
         color: #222222;
         display: block;
@@ -2988,7 +2988,7 @@ td.bundle {
         .ui-tabs-panel {
             background: #FFF none;
             border-radius: 4px;
-            border: 3px solid #418940;
+            border: 3px solid $background-color-primary;
 
             fieldset {
                 box-shadow: none;
@@ -3160,7 +3160,7 @@ nav {
 
             li {
                 display: inline;
-                color : #418940;
+                color : $background-color-primary;
                 font-style: italic;
 
                 &+li::before {
@@ -3546,7 +3546,7 @@ code {
 
 .tab-content {
     background-color: #fff;
-    border: 3px solid #418940;
+    border: 3px solid $background-color-primary;
     border-radius: 4px;
     padding: 1em;
 }
@@ -3554,16 +3554,16 @@ code {
 .nav-tabs {
     > li {
         > a {
-            background-color: #71B443;
+            background-color: $background-color-secondary;
             color: #FFFFFF;
             line-height: 1.42857143;
             margin-right: .4em;
             padding: .5em 1em;
 
             &:hover, &:focus, &:active {
-                background-color: #418940;
+                background-color: $background-color-primary;
                 border-radius: 4px 4px 0 0;
-                border: 1px solid #418940;
+                border: 1px solid $background-color-primary;
                 padding: .5em 1em;
                 text-decoration: none;
                 color: #FFFFFF;
@@ -3574,7 +3574,7 @@ code {
             a,
             a:hover,
             a:focus {
-                background-color: #418940;
+                background-color: $background-color-primary;
                 border-radius: 4px 4px 0 0;
                 color: #FFFFFF;
                 cursor: default;
@@ -3694,7 +3694,7 @@ progress {
 
 #browse-return-to-results {
     background-color: #e6e6e6;
-    border: 1px solid lighten(#418940, 30%);
+    border: 1px solid lighten($background-color-primary, 30%);
     border-bottom-width: 0;
     border-top-left-radius: 5px;
     border-top-right-radius: 5px;
@@ -3705,7 +3705,7 @@ progress {
 
 .browse-button {
     background-color: transparent;
-    border: 1px solid lighten(#418940, 30%);
+    border: 1px solid lighten($background-color-primary, 30%);
     display: block;
     overflow: hidden;
     padding: .4em .6em;
@@ -4283,7 +4283,7 @@ input.renew {
             font-weight: bold;
 
             &:hover {
-                background-color: #418940;
+                background-color: $background-color-primary;
                 color: white;
                 text-decoration: none;
             }


### PR DESCRIPTION
_variables.scss currently contains a variable,
$background-color-primary, which isn't used. I think we should use that variable anywhere the color is used, and use SASS color calculation to generate the secondary color.

The two colors can be compared in the search header: primary for the background, secondary for the submit button color.

To test, apply the patch and rebuild the staff interface CSS.

Test various pages in the staff interface to confirm that the colors look the same as before: Search header, tab colors, "Last patron" button, etc.