### PR TITLE
Bug 30952: (follow-up) Avoid nav menu jump between bold and normal

### DIFF
--- a/koha-tmpl/intranet-tmpl/prog/css/src/staff-global.scss
+++ b/koha-tmpl/intranet-tmpl/prog/css/src/staff-global.scss
@@ -394,16 +394,29 @@ aside {
             list-style: none;
 
             a {
+                border-left: 5px solid #E6E6E6;
                 color: #000;
                 display: block;
                 text-decoration: none;
                 padding: .7em .3em .7em 1.2em;
             }
 
-            &.active > a, a:hover, a.current {
+            &.active > a,
+            a:hover,
+            a.current {
                 background-color: #F3F4F4;
                 text-decoration: none;
                 color: $green-text-color;
+                border-left: solid 5px $background-color-primary;
+                font-weight: bold;
+            }
+
+            a:hover {
+                border-left: solid 5px $background-color-secondary;
+                font-weight: normal;
+            }
+
+            &.active > a:hover {
                 border-left: solid 5px $background-color-primary;
                 font-weight: bold;
             }


### PR DESCRIPTION
I think styling links with a bold hover state results in a "jumpy" look, and I seem to recall making changes in the past to issues like in response to bug reports.

I'd like to propose an alternative style for the nav menu which uses color changes to indicate the hover state. This menu can be seen in the sidebar of patron details, bibliographic details, etc.